### PR TITLE
[patch] reset ticker  whenever a batch is processed

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v4
         with:
-          go-version: "1.23"
+          go-version: "1.24"
 
       - name: Build
         run: go build -v ./...

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -40,4 +40,4 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v7
         with:
-          version: v2.60
+          version: v2.6

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -40,4 +40,4 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v6
         with:
-          version: v1.60
+          version: v2.60

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v4
         with:
-          go-version: "1.24"
+          go-version: "1.25"
 
       - name: Build
         run: go build -v ./...
@@ -38,6 +38,6 @@ jobs:
           path-to-profile: covprofile
 
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v6
+        uses: golangci/golangci-lint-action@v7
         with:
           version: v2.60

--- a/nibbler.go
+++ b/nibbler.go
@@ -150,6 +150,10 @@ func (bat *Nibbler[T]) Listen() {
 }
 
 func (bat *Nibbler[T]) listener(ticker *time.Ticker, size int) (err error) {
+	defer func() {
+		ticker.Reset(bat.cfg.TickerDuration)
+	}()
+
 	select {
 	case <-ticker.C:
 		// process non empty batch

--- a/nibbler.go
+++ b/nibbler.go
@@ -150,15 +150,12 @@ func (bat *Nibbler[T]) Listen() {
 }
 
 func (bat *Nibbler[T]) listener(ticker *time.Ticker, size int) (err error) {
-	defer func() {
-		ticker.Reset(bat.cfg.TickerDuration)
-	}()
-
 	select {
 	case <-ticker.C:
 		// process non empty batch
 		if len(bat.batch) > 0 {
 			err = bat.processBatch(TriggerTicker)
+			ticker.Reset(bat.cfg.TickerDuration)
 		}
 
 	case value := <-bat.queue:
@@ -166,6 +163,7 @@ func (bat *Nibbler[T]) listener(ticker *time.Ticker, size int) (err error) {
 		// process batch immediately if full, instead of waiting for ticker
 		if len(bat.batch) >= size {
 			err = bat.processBatch(TriggerFull)
+			ticker.Reset(bat.cfg.TickerDuration)
 		}
 	}
 

--- a/nibbler_test.go
+++ b/nibbler_test.go
@@ -160,10 +160,9 @@ func TestProcessorErr(tt *testing.T) {
 
 		nib, err := Start(&Config[string]{
 			TickerDuration: time.Second,
-			Processor: func(_ context.Context, _ Trigger, _ []string) error {
+			Processor: func(_ context.Context, _ Trigger, _ []string) error { //nolint:typecheck
 				panic(errProcessing)
 			},
-			//nolint:typecheck
 			ProcessorErr: func(failedBatch []string, err error) {
 				asserter.ErrorIs(err, errProcessing)
 				asserter.ElementsMatch([]string{"hello"}, failedBatch)

--- a/nibbler_test.go
+++ b/nibbler_test.go
@@ -161,7 +161,7 @@ func TestProcessorErr(tt *testing.T) {
 		nib, err := Start(&Config[string]{
 			TickerDuration: time.Second,
 			Processor: func(_ context.Context, _ Trigger, _ []string) error {
-				panic(errProcessing) //nolint:gocritic
+				panic(errProcessing) //nolint:typecheck
 			},
 			ProcessorErr: func(failedBatch []string, err error) {
 				asserter.ErrorIs(err, errProcessing)

--- a/nibbler_test.go
+++ b/nibbler_test.go
@@ -161,8 +161,13 @@ func TestProcessorErr(tt *testing.T) {
 		nib, err := Start(&Config[string]{
 			TickerDuration: time.Second,
 			Processor: func(_ context.Context, _ Trigger, _ []string) error {
-				panic(errProcessing)
-			}, //nolint
+				// this whole if condition is to satisfy the stupid linter
+				// which does not honour ignore directives
+				if errProcessing != nil {
+					panic(errProcessing)
+				}
+				return nil
+			},
 			ProcessorErr: func(failedBatch []string, err error) {
 				asserter.ErrorIs(err, errProcessing)
 				asserter.ElementsMatch([]string{"hello"}, failedBatch)

--- a/nibbler_test.go
+++ b/nibbler_test.go
@@ -161,8 +161,8 @@ func TestProcessorErr(tt *testing.T) {
 		nib, err := Start(&Config[string]{
 			TickerDuration: time.Second,
 			Processor: func(_ context.Context, _ Trigger, _ []string) error {
-				panic(errProcessing) //nolint:typecheck
-			},
+				panic(errProcessing)
+			}, //nolint:typecheck
 			ProcessorErr: func(failedBatch []string, err error) {
 				asserter.ErrorIs(err, errProcessing)
 				asserter.ElementsMatch([]string{"hello"}, failedBatch)

--- a/nibbler_test.go
+++ b/nibbler_test.go
@@ -160,9 +160,9 @@ func TestProcessorErr(tt *testing.T) {
 
 		nib, err := Start(&Config[string]{
 			TickerDuration: time.Second,
-			Processor: func(_ context.Context, _ Trigger, _ []string) error { //nolint:typecheck
+			Processor: func(_ context.Context, _ Trigger, _ []string) error {
 				panic(errProcessing)
-			},
+			}, //nolint
 			ProcessorErr: func(failedBatch []string, err error) {
 				asserter.ErrorIs(err, errProcessing)
 				asserter.ElementsMatch([]string{"hello"}, failedBatch)

--- a/nibbler_test.go
+++ b/nibbler_test.go
@@ -161,7 +161,7 @@ func TestProcessorErr(tt *testing.T) {
 		nib, err := Start(&Config[string]{
 			TickerDuration: time.Second,
 			Processor: func(_ context.Context, _ Trigger, _ []string) error {
-				panic(errProcessing)
+				panic(errProcessing) //nolint:gocritic
 			},
 			ProcessorErr: func(failedBatch []string, err error) {
 				asserter.ErrorIs(err, errProcessing)

--- a/nibbler_test.go
+++ b/nibbler_test.go
@@ -162,7 +162,8 @@ func TestProcessorErr(tt *testing.T) {
 			TickerDuration: time.Second,
 			Processor: func(_ context.Context, _ Trigger, _ []string) error {
 				panic(errProcessing)
-			}, //nolint:typecheck
+			},
+			//nolint:typecheck
 			ProcessorErr: func(failedBatch []string, err error) {
 				asserter.ErrorIs(err, errProcessing)
 				asserter.ElementsMatch([]string{"hello"}, failedBatch)


### PR DESCRIPTION
This may seem redundant, but improves the accuracy of the overall behaviour. 

Without the reset, the following tick could be executed immediately after a batch is processed. It could happen on the following conditions:

1. The total time taken for processing the batch
2. When N number of batches are processed, triggered by BATCH_FULL, ticker would eventually tick with a small/empty batch. Despite the channel is continuously receiving items 